### PR TITLE
Add PromptPay support to Stripe plugin

### DIFF
--- a/src/pretix/plugins/stripe/payment.py
+++ b/src/pretix/plugins/stripe/payment.py
@@ -137,7 +137,7 @@ logger = logging.getLogger('pretix.plugins.stripe')
 # Real-time payments
 # - Swish: ✓
 # - PayNow: ✗
-# - PromptPay: ✗
+# - PromptPay: ✓
 # - Pix: ✗
 #
 # Vouchers
@@ -424,6 +424,14 @@ class StripeSettingsHolder(BasePaymentProvider):
                  forms.BooleanField(
                      label='Revolut Pay',
                      disabled=self.event.currency not in ['EUR', 'GBP'],
+                     help_text=_('Some payment methods might need to be enabled in the settings of your Stripe account '
+                                 'before they work properly.'),
+                     required=False,
+                 )),
+                ('method_promptpay',
+                 forms.BooleanField(
+                     label='PromptPay',
+                     disabled=self.event.currency != 'THB',
                      help_text=_('Some payment methods might need to be enabled in the settings of your Stripe account '
                                  'before they work properly.'),
                      required=False,
@@ -1839,6 +1847,27 @@ class StripeSwish(StripeRedirectMethod):
                     "reference": payment.order.full_code,
                 },
             }
+        }
+
+
+class StripePromptPay(StripeRedirectMethod):
+    identifier = 'stripe_promptpay'
+    verbose_name = _('PromptPay via Stripe')
+    public_name = 'PromptPay'
+    method = 'promptpay'
+    confirmation_method = 'automatic'
+    explanation = _(
+        'This payment method is available to PromptPay users in Thailand. Please have your app ready.'
+    )
+
+    def is_allowed(self, request: HttpRequest, total: Decimal=None) -> bool:
+        return super().is_allowed(request, total) and request.event.currency == "THB"
+
+    def _payment_intent_kwargs(self, request, payment):
+        return {
+            "payment_method_data": {
+                "type": "promptpay",
+            },
         }
 
 

--- a/src/pretix/plugins/stripe/signals.py
+++ b/src/pretix/plugins/stripe/signals.py
@@ -47,15 +47,16 @@ def register_payment_provider(sender, **kwargs):
     from .payment import (
         StripeAffirm, StripeAlipay, StripeBancontact, StripeCC, StripeEPS,
         StripeGiropay, StripeIdeal, StripeKlarna, StripeMobilePay,
-        StripeMultibanco, StripePayPal, StripePrzelewy24, StripeRevolutPay,
-        StripeSEPADirectDebit, StripeSettingsHolder, StripeSofort, StripeSwish,
-        StripeTwint, StripeWeChatPay,
+        StripeMultibanco, StripePayPal, StripePrzelewy24, StripePromptPay,
+        StripeRevolutPay, StripeSEPADirectDebit, StripeSettingsHolder,
+        StripeSofort, StripeSwish, StripeTwint, StripeWeChatPay,
     )
 
     return [
         StripeSettingsHolder, StripeCC, StripeGiropay, StripeIdeal, StripeAlipay, StripeBancontact,
-        StripeSofort, StripeEPS, StripeMultibanco, StripePrzelewy24, StripeRevolutPay, StripeWeChatPay,
-        StripeSEPADirectDebit, StripeAffirm, StripeKlarna, StripePayPal, StripeSwish, StripeTwint, StripeMobilePay
+        StripeSofort, StripeEPS, StripeMultibanco, StripePrzelewy24, StripePromptPay, StripeRevolutPay,
+        StripeWeChatPay, StripeSEPADirectDebit, StripeAffirm, StripeKlarna, StripePayPal, StripeSwish,
+        StripeTwint, StripeMobilePay
     ]
 
 

--- a/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
+++ b/src/pretix/plugins/stripe/static/pretixplugins/stripe/pretix-stripe.js
@@ -325,6 +325,8 @@ $(function () {
     } else if ($("#stripe_payment_intent_next_action_redirect_url").length) {
         let payment_intent_next_action_redirect_url = $.trim($("#stripe_payment_intent_next_action_redirect_url").html());
         pretixstripe.handlePaymentRedirectAction(payment_intent_next_action_redirect_url);
+    } else if ($.trim($("#stripe_payment_intent_action_type").html()) === "promptpay_display_qr_code") {
+        waitingDialog.hide();
     } else if ($.trim($("#stripe_payment_intent_action_type").html()) === "wechat_pay_display_qr_code") {
         let payment_intent_client_secret = $.trim($("#stripe_payment_intent_client_secret").html());
         pretixstripe.handleWechatAction(payment_intent_client_secret);

--- a/src/pretix/plugins/stripe/templates/pretixplugins/stripe/pending.html
+++ b/src/pretix/plugins/stripe/templates/pretixplugins/stripe/pending.html
@@ -58,6 +58,14 @@
     <div class="text-center">
         <script type="text/plain" data-size="150" data-replace-with-qr>{{ payment_info.wechat.qr_code_url }}</script>
     </div>
+{% elif payment.state == "created" and payment.provider == "stripe_promptpay" %}
+    <p>{% blocktrans trimmed %}
+        Please scan the QR code below to complete your PromptPay payment.
+        Once you have completed your payment, you can refresh this page.
+    {% endblocktrans %}</p>
+    <div class="text-center">
+        <img src="{{ payment_info.next_action.promptpay_display_qr_code.image_url_svg }}" alt="{% trans 'PromptPay QR code' %}" />
+    </div>
 {% else %}
     <p>{% blocktrans trimmed %}
         The payment transaction could not be completed for the following reason:

--- a/src/pretix/plugins/stripe/templates/pretixplugins/stripe/sca.html
+++ b/src/pretix/plugins/stripe/templates/pretixplugins/stripe/sca.html
@@ -28,7 +28,11 @@
 
         </div>
         <div class="panel-body embed-responsive embed-responsive-sca" id="scacontainer">
-
+            {% if payment_intent_promptpay_image_url %}
+                <div class="text-center">
+                    <img src="{{ payment_intent_promptpay_image_url }}" alt="{% trans 'PromptPay QR code' %}" />
+                </div>
+            {% endif %}
         </div>
     </div>
     <div class="row checkout-button-row">

--- a/src/pretix/plugins/stripe/views.py
+++ b/src/pretix/plugins/stripe/views.py
@@ -595,7 +595,7 @@ class ScaView(StripeOrderView, View):
 
         if intent.status == 'requires_action' and intent.next_action.type in [
             'use_stripe_sdk', 'redirect_to_url', 'alipay_handle_redirect', 'wechat_pay_display_qr_code',
-            'swish_handle_redirect_or_display_qr_code', 'multibanco_display_details',
+            'swish_handle_redirect_or_display_qr_code', 'multibanco_display_details', 'promptpay_display_qr_code',
         ]:
             ctx = {
                 'order': self.order,
@@ -613,6 +613,8 @@ class ScaView(StripeOrderView, View):
             elif intent.next_action.type == 'multibanco_display_details':
                 ctx['payment_intent_next_action_redirect_url'] = intent.next_action.multibanco_display_details['hosted_voucher_url']
                 ctx['payment_intent_redirect_action_handling'] = 'iframe'
+            elif intent.next_action.type == 'promptpay_display_qr_code':
+                ctx['payment_intent_promptpay_image_url'] = intent.next_action.promptpay_display_qr_code['image_url_svg']
 
             r = render(request, 'pretixplugins/stripe/sca.html', ctx)
             r._csp_ignore = True


### PR DESCRIPTION
## Summary
- add PromptPay real-time payment method via Stripe
- expose PromptPay toggle in Stripe settings
- register PromptPay provider
- display PromptPay QR codes during checkout and pending states

## Testing
- `pytest src/tests/plugins/stripe -q` *(fails: ModuleNotFoundError: No module named 'fakeredis')*

------
https://chatgpt.com/codex/tasks/task_e_689eaf471a7c8327a292a73bcb84ed4a